### PR TITLE
Bug fixes

### DIFF
--- a/lua/fishtank/fish.lua
+++ b/lua/fishtank/fish.lua
@@ -3,6 +3,7 @@ local constants = require('fishtank.constants')
 local luaUtils = require('fishtank.util.lua')
 local options = require('fishtank.options')
 local path = require('fishtank.path')
+local vimUtils = require('fishtank.util.vim')
 
 Fish = {
     position = { row = 0, col = 0 },
@@ -49,6 +50,7 @@ function Fish:initialize()
         zindex = 999,
         style = 'minimal',
         noautocmd = true,
+        border = '',
     })
 
     -- set the window's highlight namespace
@@ -95,7 +97,10 @@ end
 
 -- closes a fish's window
 function Fish:close()
-    vim.api.nvim_win_close(self.windowID, true)
+    if vim.api.nvim_win_is_valid(self.windowID) then
+        vim.api.nvim_win_close(self.windowID, true)
+    end
+
     self.bufferID = nil
     self.windowID = nil
 end

--- a/lua/fishtank/internals.lua
+++ b/lua/fishtank/internals.lua
@@ -43,6 +43,14 @@ local redrawFishtank = function()
     end
 
     for i, fish in ipairs(globalState.fishList) do
+        -- if the window is somehow closed
+        if not vim.api.nvim_win_is_valid(fish.windowID) then
+            -- TODO: should be made per fish once we have multiple fish support
+            M.hideFishtank()
+            M.userNotIdle()
+            break
+        end
+
         -- move the fishtank window
         vim.api.nvim_win_set_config(fish.windowID, {
             relative = 'editor',


### PR DESCRIPTION
- Fixed fish having window borders when `opt.winborder` is set.
- Fixed spammed errors if the fish window is manually closed (via \<C-w\>o)

<img height="200" alt="Screenshot 2025-08-06 at 11 10 42 am" src="https://github.com/user-attachments/assets/5578847e-7457-425b-bba0-843ab80e232e" />
<img height="200" alt="Screenshot 2025-08-06 at 11 11 29 am" src="https://github.com/user-attachments/assets/8a70acc5-7099-4267-a79f-862be0a069c0" />

> Issues, comments, discussions, feature requests, and pull requests are welcome. At this point, I will be happy if anyone other than me ever sees this.

I saw it :)